### PR TITLE
Changes to use label not MAINTAINER

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN /tmp/install && rm /tmp/install
 # Share the same base image to reduce layers
 FROM hypertrace/java:11
 
-MAINTAINER Hypertrace "https://www.hypertrace.org/"
+LABEL maintainer="Hypertrace https://www.hypertrace.org/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY docker-bin/* /usr/local/bin/


### PR DESCRIPTION
per https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Thx @jcchavezs for the hint!

```
$ docker inspect XXX
--snip--
            "Labels": {
                "maintainer": "Hypertrace https://www.hypertrace.org/"
            },
````