### PR TITLE
Uses file extension to clarify the install script isn't a directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,13 +6,12 @@ ENV CONFLUENT_VERSION=5.5.1 SCALA_VERSION=2.12
 
 USER root
 WORKDIR /install
-ADD install /tmp/install
-RUN /tmp/install && rm /tmp/install
+COPY install.sh /tmp/
+RUN /tmp/install.sh && rm /tmp/install.sh
 
 # Share the same base image to reduce layers
 FROM hypertrace/java:11
-
-LABEL maintainer="Hypertrace https://www.hypertrace.org/"
+LABEL MAINTAINER Hypertrace "https://www.hypertrace.org/"
 
 # Add HEALTHCHECK and ENTRYPOINT scripts into the default search path
 COPY docker-bin/* /usr/local/bin/

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("org.hypertrace.docker-plugin") version "0.6.1"
-  id("org.hypertrace.docker-publish-plugin") version "0.6.1"
+  id("org.hypertrace.docker-plugin") version "0.7.1"
+  id("org.hypertrace.docker-publish-plugin") version "0.7.1"
 }
 
 hypertraceDocker {

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -24,7 +24,7 @@ sed -i 's~INFO~WARN~g' etc/schema-registry/log4j.properties
 echo 'org.glassfish.jersey.internal.inject.Providers = SEVERE' > etc/schema-registry/logging.properties
 
 # default to listen on 8081 and connect to "kafka" hostname on default port
-cat > etc/schema-registry/schema-registry.properties <<-EOF
+cat > etc/schema-registry/schema-registry.properties <<-'EOF'
 avro.compatibility.level=full_transitive
 kafkastore.group.id=hypertrace-schema-registry
 listeners=http://0.0.0.0:8081


### PR DESCRIPTION
It is normal in UNIX to not add a shell script suffix even if it is
common in projects that have both windows and UNIX commands in them.

For example, the canonical name for the Docker HEALTHCHECK command is
`docker-healthcheck`, not `docker-healthcheck.sh`.

There's a special case @jcchavezs noticed when looking at how the
installation layer is setup. The word `install` is both used for a
root directory `/install` and also a script that populates that,
`/tmp/install`. This distracted him from other work and that's an
anti-goal.

Instead of deciding a different name for `/install` or a different
name for the `/tmp/install` script, this appends an otherwise
unnecessary `.sh` to the install script to avoid the problem without
creating a new naming problem.