### PR TITLE
rootless image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,9 @@ ENV SCHEMA_REGISTRY_HEAP_OPTS="-Xms128M -Xmx200M"
 # Stop JUL spam about io.confluent.kafka.schemaregistry.rest.resources.ServerMetadataResource
 ENV SCHEMA_REGISTRY_LOG4J_OPTS="-Dlog4j.configuration=file:./etc/schema-registry/log4j.properties -Djava.util.logging.config.file=./etc/schema-registry/logging.properties"
 
+RUN mkdir -p /opt/schema-registry/logs && \
+    chmod a+w /opt/schema-registry/etc/schema-registry/schema-registry.properties /opt/schema-registry/logs
+
 EXPOSE 8081
 
 # We use start period of 30s to avoid marking the container unhealthy on slow or contended CI hosts


### PR DESCRIPTION
To enable deployment of this container to Openshift rootless image is required. Provided change only enables writing to selected directories to generated user id within given range. This change enable writing of the logs and update of `schema-registry.properties` by env vars that are propagated by start shell script into properties file.