### PR TITLE
upgrade schema registry to version 7.3.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM cimg/openjdk:14.0.2 AS install
 
 # Use latest stable release here
-ENV CONFLUENT_VERSION=7.2.1
+ENV CONFLUENT_VERSION=7.3.1
 
 USER root
 WORKDIR /install

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -4,7 +4,7 @@ set -eux
 
 echo "*** Downloading Schema Registry"
 # download confluent binaries
-curl -sSL http://packages.confluent.io/archive/7.2/confluent-community-$CONFLUENT_VERSION.tar.gz | tar xz \
+curl -sSL http://packages.confluent.io/archive/7.3/confluent-community-$CONFLUENT_VERSION.tar.gz | tar xz \
 confluent-$CONFLUENT_VERSION/bin/schema-registry-run-class \
 confluent-$CONFLUENT_VERSION/etc/schema-registry \
 confluent-$CONFLUENT_VERSION/share/java/confluent-common \

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -122,7 +122,7 @@ prometheus:
     enabled: false
     image:
       repository: hypertrace/prometheus-jmx-exporter
-      tag: 0.1.1
+      tag: 0.1.2
       pullPolicy: IfNotPresent
     port: 5560
     resources:


### PR DESCRIPTION
Fixes the following vulnerabilities:
1. CVE-2022-42003
2. CVE-2022-42004
3. CVE-2022-3171
4. CVE-2022-3509
5. CVE-2022-3510
6. CVE-2022-24823
7. CVE-2022-2048
8. CVE-2022-2047
9. CVE-2021-28170
10. CVE-2022-36944
11. CVE-2022-25857
12. CVE-2022-38749
13. CVE-2022-38750
14. CVE-2022-38751
15. CVE-2022-38752
16. CVE-2022-41854
