### PR TITLE
Update ingress to work with k8s version 1.22 and beyond

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $serviceName := include "schema-registry.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "schema-registry.fullname" . }}
@@ -15,9 +15,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path | default "/" | quote }}
+            pathType: Prefix
             backend:
-              serviceName: {{ default $serviceName .serviceName | quote }}
-              servicePort: {{ default "8081" .port }}
+              service:
+                name: {{ default $serviceName .serviceName | quote }}
+                port:
+                  number: {{ default "8081" .port }}
           {{- end }}
       {{- if .name }}
       host: {{ .name | quote }}


### PR DESCRIPTION
## Description
Update the ingress definition to work with newer versions of k8s where `extensions/v1beta1` is no longer available: 

### Testing
Tested by building version locally and installing
```
helm install --namespace=kafka-infrastructure --timeout=10m0s --values=./schema-registry/values.yaml  --version=2.0.2 schema-registry ./schema-registry-2.0.2.tar.gz
```

### Checklist:
- [X] My changes generate no new warnings

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22