### PR TITLE
chore: upgrade schema-registry to version 7.5.2

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,8 +1,0 @@
-# org.yaml:snakeyaml (from upstream opensource dependency)
-CVE-2022-1471 exp:2023-09-30
-
-# org.json:json (from upstream opensource dependency)
-CVE-2022-45688 exp:2023-09-30
-
-# org.xerial.snappy:snappy-java (from upstream opensource dependency)
-CVE-2023-34455 exp:2023-09-30

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-# Using the same image as we use in CircleCI to avoid transfer costs
 FROM ubuntu:22.04 AS install
 
 # Use latest stable release here

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,17 @@
 # Using the same image as we use in CircleCI to avoid transfer costs
-FROM cimg/openjdk:14.0.2 AS install
+FROM ubuntu:22.04 AS install
 
 # Use latest stable release here
-ENV CONFLUENT_VERSION=7.3.1
+ENV CONFLUENT_VERSION=7.5.2
 
 USER root
 WORKDIR /install
 COPY install.sh /tmp/
+RUN apt-get update && apt-get install curl -y
 RUN /tmp/install.sh && rm /tmp/install.sh
+RUN rm /install/share/java/schema-registry/zookeeper-3.6.3.jar /install/share/java/schema-registry/zookeeper-jute-3.6.3.jar && \
+    curl -sSL -o /install/share/java/schema-registry/zookeeper-3.8.3.jar https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.8.3/zookeeper-3.8.3.jar && \
+    curl -sSL -o /install/share/java/schema-registry/zookeeper-jute-3.8.3.jar https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/3.8.3/zookeeper-jute-3.8.3.jar
 
 # Share the same base image to reduce layers
 FROM hypertrace/java:11

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -4,7 +4,7 @@ set -eux
 
 echo "*** Downloading Schema Registry"
 # download confluent binaries
-curl -sSL http://packages.confluent.io/archive/7.3/confluent-community-$CONFLUENT_VERSION.tar.gz | tar xz \
+curl -sSL http://packages.confluent.io/archive/7.5/confluent-community-$CONFLUENT_VERSION.tar.gz | tar xz \
 confluent-$CONFLUENT_VERSION/bin/schema-registry-run-class \
 confluent-$CONFLUENT_VERSION/etc/schema-registry \
 confluent-$CONFLUENT_VERSION/share/java/confluent-common \


### PR DESCRIPTION
fixes the following vulnerabilities:
```
Total: 27 (UNKNOWN: 0, LOW: 5, MEDIUM: 11, HIGH: 10, CRITICAL: 1)

┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│                           Library                            │    Vulnerability    │ Severity │ Status │ Installed Version │                  Fixed Version                   │                            Title                             │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.google.guava:guava (guava-30.1.1-jre.jar)                │ CVE-2023-2976       │ MEDIUM   │ fixed  │ 30.1.1-jre        │ 32.0.0-android                                   │ guava: insecure temporary directory creation                 │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-2976                    │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              ├─────────────────────┼──────────┤        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2020-8908       │ LOW      │        │                   │                                                  │ local information disclosure via temporary directory created │
│                                                              │                     │          │        │                   │                                                  │ with unsafe permissions                                      │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2020-8908                    │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.squareup.okio:okio (okio-3.0.0.jar)                      │ CVE-2023-3635       │ MEDIUM   │        │ 3.0.0             │ 3.4.0, 1.17.6                                    │ okio: GzipSource class improper exception handling           │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-3635                    │
├──────────────────────────────────────────────────────────────┤                     │          │        │                   ├──────────────────────────────────────────────────┤                                                              │
│ com.squareup.okio:okio-jvm (okio-jvm-3.0.0.jar)              │                     │          │        │                   │ 3.4.0                                            │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.avro:avro (avro-1.11.0.jar)                       │ CVE-2023-39410      │ HIGH     │        │ 1.11.0            │ 1.11.3                                           │ apache-avro: Apache Avro Java SDK: Memory when deserializing │
│                                                              │                     │          │        │                   │                                                  │ untrusted data in Avro...                                    │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-39410                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.zookeeper:zookeeper (zookeeper-3.6.3.jar)         │ CVE-2023-44981      │ CRITICAL │        │ 3.6.3             │ 3.7.2, 3.8.3, 3.9.1                              │ zookeeper: Authorization Bypass in Apache ZooKeeper          │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-44981                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.bitbucket.b_c:jose4j (jose4j-0.7.9.jar)                  │ CVE-2023-31582      │ HIGH     │        │ 0.7.9             │ 0.9.3                                            │ jose4j: Insecure iteration count setting                     │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-31582                   │
│                                                              ├─────────────────────┼──────────┤        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                              │ GHSA-jgvc-jfgh-rjvv │ MEDIUM   │        │                   │                                                  │ Chosen Ciphertext Attack in Jose4j                           │
│                                                              │                     │          │        │                   │                                                  │ https://github.com/advisories/GHSA-jgvc-jfgh-rjvv            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty.http2:http2-hpack                          │ CVE-2023-36478      │ HIGH     │        │ 9.4.48.v20220622  │ 10.0.16, 11.0.16, 9.4.53                         │ jetty: hpack header values cause denial of service in http/2 │
│ (http2-hpack-9.4.48.v20220622.jar)                           │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-36478                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-http                                 │ CVE-2023-40167      │ MEDIUM   │        │                   │ 9.4.52, 10.0.16, 11.0.16, 12.0.1                 │ jetty: Improper validation of HTTP/1 content-length          │
│ (jetty-http-9.4.48.v20220622.jar)                            │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-40167                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-server                               │ CVE-2023-26048      │          │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14               │ jetty-server: OutOfMemoryError for large multipart without   │
│ (jetty-server-9.4.48.v20220622.jar)                          │                     │          │        │                   │                                                  │ filename read via request.getParameter()                     │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26048                   │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-26049      │ LOW      │        │                   │ 9.4.51.v20230217, 10.0.14, 11.0.14, 12.0.0.beta0 │ jetty-server: Cookie parsing of quoted values can exfiltrate │
│                                                              │                     │          │        │                   │                                                  │ values from other cookies...                                 │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-26049                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-servlets                             │ CVE-2023-36479      │          │        │                   │ 9.4.52, 10.0.16, 11.0.16                         │ jetty: Improper addition of quotation marks to user inputs   │
│ (jetty-servlets-9.4.48.v20220622.jar)                        │                     │          │        │                   │                                                  │ in CgiServlet                                                │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-36479                   │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.eclipse.jetty:jetty-xml (jetty-xml-9.4.48.v20220622.jar) │ GHSA-58qw-p7qm-5rvh │          │        │                   │ 10.0.16, 11.0.16, 12.0.0, 9.4.52                 │ Eclipse Jetty XmlParser allows arbitrary DOCTYPE             │
│                                                              │                     │          │        │                   │                                                  │ declarations                                                 │
│                                                              │                     │          │        │                   │                                                  │ https://github.com/advisories/GHSA-58qw-p7qm-5rvh            │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.json:json (json-20220320.jar)                            │ CVE-2022-45688      │ HIGH     │        │ 20220320          │ 20230227                                         │ json stack overflow vulnerability                            │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2022-45688                   │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-5072       │          │        │                   │ 20231013                                         │ JSON-java: parser confusion leads to OOM                     │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-5072                    │
├──────────────────────────────────────────────────────────────┼─────────────────────┤          │        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.xerial.snappy:snappy-java (snappy-java-1.1.8.4.jar)      │ CVE-2023-34455      │          │        │ 1.1.8.4           │ 1.1.10.1                                         │ snappy-java: Unchecked chunk length leads to DoS             │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34455                   │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              ├─────────────────────┤          │        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-43642      │          │        │                   │ 1.1.10.4                                         │ snappy-java: Missing upper bound check on chunk length in    │
│                                                              │                     │          │        │                   │                                                  │ snappy-java can lead...                                      │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-43642                   │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              ├─────────────────────┼──────────┤        │                   ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-34453      │ MEDIUM   │        │                   │ 1.1.10.1                                         │ snappy-java: Integer overflow in shuffle leads to DoS        │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34453                   │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              ├─────────────────────┤          │        │                   │                                                  ├──────────────────────────────────────────────────────────────┤
│                                                              │ CVE-2023-34454      │          │        │                   │                                                  │ snappy-java: Integer overflow in compress leads to DoS       │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2023-34454                   │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
│                                                              │                     │          │        │                   │                                                  │                                                              │
├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┤        ├───────────────────┼──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.yaml:snakeyaml (snakeyaml-1.32.jar)                      │ CVE-2022-1471       │ HIGH     │        │ 1.32              │ 2.0                                              │ SnakeYaml: Constructor Deserialization Remote Code Execution │
│                                                              │                     │          │        │                   │                                                  │ https://avd.aquasec.com/nvd/cve-2022-1471                    │
└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```