### PR TITLE
chore: fix schema-compatibility cronjob

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,8 @@
 # com.google.protobuf:protobuf-java
 CVE-2024-7254 exp:2024-10-31
+
 # commons-io:commons-io
 CVE-2024-47554 exp:2024-10-31
+
+# org.apache.avro:avro
+CVE-2024-47561 exp:2024-10-31

--- a/helm/templates/schema-compatibility/cronjob.yaml
+++ b/helm/templates/schema-compatibility/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               configMap:
                 name: {{ .Values.schemaCompatibility.name }}
           containers:
-            - command: [ "/bin/sh", "-c" ]
+            - command: [ "/bin/bash", "-ce" ]
               args:
                 - |
                   finish() {


### PR DESCRIPTION
fixes:
```
/bin/sh: 9: source: not found
Traceback (most recent call last):
  File "/opt/schema-compatibility/cron-job.py", line 1, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```